### PR TITLE
Suppress success message

### DIFF
--- a/Terminal Notifier/AppDelegate.m
+++ b/Terminal Notifier/AppDelegate.m
@@ -218,7 +218,6 @@
 - (void)userNotificationCenter:(NSUserNotificationCenter *)center
         didDeliverNotification:(NSUserNotification *)userNotification;
 {
-  printf("* Notification delivered.\n");
   exit(0);
 }
 


### PR DESCRIPTION
There is no need to print '\* Notification delivered' on success. Shell clients can test $? for success instead. This change makes it unnecessary to redirect terminal-notifier stdout to /dev/null in clients that do not wish to see this output.
