### PR TITLE
[Ruby] Add an unsupported platform error to replace stderr

### DIFF
--- a/Ruby/lib/terminal-notifier.rb
+++ b/Ruby/lib/terminal-notifier.rb
@@ -25,7 +25,7 @@ module TerminalNotifier
       end
       result
     else
-      raise UnsupportedPlatformError, "Warning: terminal-notifier is only supported on Mac OS X 10.8, or higher."
+      raise UnsupportedPlatformError, "terminal-notifier is only supported on Mac OS X 10.8, or higher."
     end
   end
 


### PR DESCRIPTION
I didn't like seeing https://github.com/alloy/terminal-notifier/pull/23 getting merged. I agree with @alloy that the `available?` method is the proper way to go about incompatibility. Raising an exception makes more sense. I've added an exception class as well so it looks more graceful. 

It may be a pain (@mgrosso) but replacing the line `TerminalNotifier.notify('foo', title: 'bar')` with `TerminalNotifier.notify('foo', title: 'bar') if TerminalNotifier.available?` is relatively no trouble. 

`%s/TerminalNotifier\.notify('foo', title: 'bar')/TerminalNotifier\.notify('foo', title: 'bar') if TerminalNotifier\.available?/`
