### PR TITLE
Clearing some TODOs

### DIFF
--- a/Terminal Notifier/AppDelegate.m
+++ b/Terminal Notifier/AppDelegate.m
@@ -173,10 +173,9 @@
   NSLog(@"     open: %@", open);
 
   BOOL success = YES;
-  // TODO this loses NO if a consecutive call does succeed
-  if (bundleID) success = [self activateAppWithBundleID:bundleID] && success;
-  if (command)  success = [self executeShellCommand:command] && success;
-  if (open)     success = [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:open]] && success;
+  if (bundleID) success &= [self activateAppWithBundleID:bundleID];
+  if (command)  success &= [self executeShellCommand:command];
+  if (open)     success &= [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:open]];
 
   exit(success ? 0 : 1);
 }
@@ -217,7 +216,6 @@
   return [task terminationStatus] == 0;
 }
 
-// TODO is this really needed?
 - (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center
      shouldPresentNotification:(NSUserNotification *)userNotification;
 {


### PR DESCRIPTION
The TODO at line 176 was actually already fixed but an and_eq is slightly simpler than the previous statements.
For the TODO at line 220: whether or not this is _needed_ is very difficult to determine. Sometimes NC decides not post a notification because the application posting it is already 'active' which doesn't really apply to terminal-notifier. However, having this here ensure that the notification is posted either way, so it probably good to have.
