### PR TITLE
set a default sender, if one is not passed in

### DIFF
--- a/Terminal Notifier/AppDelegate.m
+++ b/Terminal Notifier/AppDelegate.m
@@ -132,6 +132,11 @@ InstallFakeBundleIdentifierHook()
       exit(0);
     }
 
+    // If the `-sender` is not set, default it to com.apple.Terminal
+    if (! defaults[@"sender"]) {
+      [defaults setObject:@"com.apple.Terminal" forKey:@"sender"];
+    }
+
     // Install the fake bundle ID hook so we can fake the sender. This also
     // needs to be done to be able to remove a message.
     if (defaults[@"sender"]) {


### PR DESCRIPTION
I rarely touch Objective C, so this may a bad way to do this.

If `-sender` is not passed in, default it to `com.apple.Terminal`.

Tested that it works locally.

Related to issue #57 
