### PR TITLE
Accept non-file image URIs

### DIFF
--- a/Terminal Notifier/AppDelegate.m
+++ b/Terminal Notifier/AppDelegate.m
@@ -205,10 +205,11 @@ isMavericks()
 
 - (NSImage*)getImageFromURL:(NSString *) url;
 {
-  if(!contains(url, @"file://")){ // Prefix file:// if not present
-    url = [NSString stringWithFormat:@"%@%@", @"file://", url];
-  }
   NSURL *imageURL = [NSURL URLWithString:url];
+  if([[imageURL scheme] length] == 0){ // Prefix file:// if no scheme
+    url = [NSString stringWithFormat:@"%@%@", @"file://", url];
+    imageURL = [NSURL URLWithString:url];
+  }
   return [[NSImage alloc] initWithContentsOfURL:imageURL];
 }
 


### PR DESCRIPTION
'appIcon' and 'contentImage' options could actually accept data:,
http(s):, etc URIs. However, the fact that the current version checks
explicitly for file:// URIs cripples that use case.

This commit tries to treat the given string as a URI. However, if the
URI does not have a scheme, then 'file://' is appended and the resulting
string is re-interpreted as the final URI. Otherwise, we are set anyway.
