### PR TITLE
get imageURL with fileURLWithPath if no scheme

### DIFF
--- a/Terminal Notifier/AppDelegate.m
+++ b/Terminal Notifier/AppDelegate.m
@@ -208,8 +208,7 @@ isMavericks()
   NSURL *imageURL = [NSURL URLWithString:url];
   if([[imageURL scheme] length] == 0){
     // Prefix 'file://' if no scheme
-    url = [NSString stringWithFormat:@"%@%@", @"file://", url];
-    imageURL = [NSURL URLWithString:url];
+    imageURL = [NSURL fileURLWithPath:url];
   }
   return [[NSImage alloc] initWithContentsOfURL:imageURL];
 }


### PR DESCRIPTION
This supports spaces and multibyte characters in file path.
