### PR TITLE
Prevented exceptions on non-Mac OS X platforms

### DIFF
--- a/Ruby/lib/terminal-notifier.rb
+++ b/Ruby/lib/terminal-notifier.rb
@@ -6,7 +6,7 @@ module TerminalNotifier
   class UnsupportedPlatformError < StandardError; end
   # Returns wether or not the current platform is Mac OS X 10.8, or higher.
   def self.available?
-    @available ||= Gem::Version.new(version) > Gem::Version.new('10.8')
+    @available ||= (/darwin/ =~ RUBY_PLATFORM) && Gem::Version.new(version) > Gem::Version.new('10.8')
   end
 
   def self.version
@@ -25,7 +25,7 @@ module TerminalNotifier
       end
       result
     else
-      raise UnsupportedPlatformError, "terminal-notifier is only supported on Mac OS X 10.8, or higher."
+      STDERR.print "terminal-notifier is only supported on Mac OS X 10.8, or higher."
     end
   end
 


### PR DESCRIPTION
Fixed the version error and also prevented the exception from being thrown on non-Mac OSX platforms. This was screwing up guard notifications on Linux in cross platform projects, by causing RSpec to report a failure even though all the tests had passed.
