### PR TITLE
allows loading of icons via http scheme

### DIFF
--- a/Terminal Notifier/Terminal Notifier-Info.plist
+++ b/Terminal Notifier/Terminal Notifier-Info.plist
@@ -32,7 +32,12 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-  <key>NSUserNotificationAlertStyle</key>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>NSUserNotificationAlertStyle</key>
 	<string>alert</string>
 </dict>
 </plist>


### PR DESCRIPTION
- Key `NSAppTransportSecurity` disallows `http` by default, and requires `https`
- Some usable icon resources (loaded via `-appIcon` or otherwise) are not readily accessible via `http`

Before:

```shell
$ terminal-notifier -t Homebrew -message 'Homebrew upgraded!' -timeout 10 -open file:///tmp/org.boneskull.homebrew-upgrade.log -group org.boneskull.hombrew-upgrade -appIcon http://brew.sh/img/homebrew-256x256.png
2016-10-06 10:43:57.173 terminal-notifier[9174:16746114] App Transport Security has blocked a cleartext HTTP (http://) resource load since it is insecure. Temporary exceptions can be configured via your app's Info.plist file.
```

![screenshot](https://cl.ly/2o2o3R0x2U02/Image%202016-10-06%20at%2011.02.28.png)

After:

```shell
$ terminal-notifier -t Homebrew -message 'Homebrew upgraded!' -timeout 10 -open file:///tmp/org.boneskull.homebrew-upgrade.log -group org.boneskull.hombrew-upgrade -appIcon http://brew.sh/img/homebrew-256x256.png -t Homebrew -message 'Homebrew upgraded!' -timeout 10 -open file:///tmp/org.boneskull.homebrew-upgrade.log -group org.boneskull.hombrew-upgrade -appIcon http://brew.sh/img/homebrew-256x256.png
```

![screenshot](https://cl.ly/1t3s2Z1h2H2y/Image%202016-10-06%20at%2011.04.22.png)

* * *

**Caveat**: I'm ignorant about what potential problems this could cause otherwise.  In my limited testing, the setting `NSAllowsArbitraryLoadsInWebContent` was insufficient to allow the resource.  I didn't try anything else.

Sorry to waste your time if this has been addressed before.  I also understand if you think it's not a good idea.