### PR TITLE
Return result of notifications

### DIFF
--- a/Ruby/lib/terminal-notifier.rb
+++ b/Ruby/lib/terminal-notifier.rb
@@ -56,6 +56,7 @@ module TerminalNotifier
       result.length == 0 || result.downcase.gsub(/\W+/,'_').to_sym
     end
   end
+  module_function :notify_result
   
   # Sends a User Notification and returns whether or not it was a success.
   #

--- a/Ruby/lib/terminal-notifier.rb
+++ b/Ruby/lib/terminal-notifier.rb
@@ -51,7 +51,7 @@ module TerminalNotifier
   # Raises if not supported on the current platform.
   def notify(message, options = {}, verbose = false)
     result = TerminalNotifier.execute(verbose, options.merge(:message => message))
-    $? && $?.success? && (result.length > 0 ? result.downcase.gsub(/[@\s]/,'_').to_sym : true)
+    $? && $?.success? && (result.length == 0 || result.downcase.gsub(/\W+/,'_').to_sym)
   end
   module_function :notify
 

--- a/Ruby/lib/terminal-notifier.rb
+++ b/Ruby/lib/terminal-notifier.rb
@@ -50,8 +50,8 @@ module TerminalNotifier
   #
   # Raises if not supported on the current platform.
   def notify(message, options = {}, verbose = false)
-    TerminalNotifier.execute(verbose, options.merge(:message => message))
-    $? && $?.success?
+    result = TerminalNotifier.execute(verbose, options.merge(:message => message))
+    $? && $?.success? && (result.length > 0 ? result.downcase.gsub(/[@\s]/,'_').to_sym : true)
   end
   module_function :notify
 

--- a/Ruby/lib/terminal-notifier.rb
+++ b/Ruby/lib/terminal-notifier.rb
@@ -30,6 +30,33 @@ module TerminalNotifier
     end
   end
 
+  # Cleans up the result of a notification, making it easier to work it
+  # 
+  # The result of a notification is downcased, then groups of 1 or more
+  # non-word characters are replaced with an underscore, before being
+  # symbolised. 
+  #
+  # If the reply option was given, then instead of going through the 
+  # above process, the result is returned with no changes as a string.
+  # 
+  # Examples are:
+  #
+  # notify_result('Test', {}) #=> :test
+  # notify_result('No, sir', {}) #=> :no_sir
+  # notify_result('@timeout', {}) #=> :_timeout
+  # notify_result('@closeaction', {}) #=> :_closeaction
+  # notify_result('I like pie', {reply: true}) #=> 'I like pie'
+  # notify_result('I do not like pie', {'reply' => true}) #=> 'I do not like pie'
+  # notify_result('@timeout', {'reply' => true}) #=> '@timeout'
+  # notify_result('I may like pie', {}) #=> :i_may_like_pie
+  def notify_result(result, options)
+    if options[:reply] || options['reply']
+      result
+    else
+      result.length == 0 || result.downcase.gsub(/\W+/,'_').to_sym
+    end
+  end
+  
   # Sends a User Notification and returns whether or not it was a success.
   #
   # The available options are `:title`, `:group`, `:activate`, `:open`,
@@ -51,7 +78,7 @@ module TerminalNotifier
   # Raises if not supported on the current platform.
   def notify(message, options = {}, verbose = false)
     result = TerminalNotifier.execute(verbose, options.merge(:message => message))
-    $? && $?.success? && (result.length == 0 || result.downcase.gsub(/\W+/,'_').to_sym)
+    $? && $?.success? && notify_result(result, options)
   end
   module_function :notify
 

--- a/Ruby/lib/terminal-notifier.rb
+++ b/Ruby/lib/terminal-notifier.rb
@@ -39,6 +39,9 @@ module TerminalNotifier
   # If the reply option was given, then instead of going through the 
   # above process, the result is returned with no changes as a string.
   # 
+  # If the always_string param is set to true, a the result is returned
+  # with no changes as a string, like above.
+  #
   # Examples are:
   #
   # notify_result('Test', {}) #=> :test
@@ -49,8 +52,8 @@ module TerminalNotifier
   # notify_result('I do not like pie', {'reply' => true}) #=> 'I do not like pie'
   # notify_result('@timeout', {'reply' => true}) #=> '@timeout'
   # notify_result('I may like pie', {}) #=> :i_may_like_pie
-  def notify_result(result, options)
-    if options[:reply] || options['reply']
+  def notify_result(result, options, always_string = false)
+    if options[:reply] || options['reply'] || always_string
       result
     else
       result.length == 0 || result.downcase.gsub(/\W+/,'_').to_sym
@@ -77,9 +80,9 @@ module TerminalNotifier
   #   TerminalNotifier.notify('Hello World', :sound => 'default')
   #
   # Raises if not supported on the current platform.
-  def notify(message, options = {}, verbose = false)
+  def notify(message, options = {}, verbose = false, always_string = false)
     result = TerminalNotifier.execute(verbose, options.merge(:message => message))
-    $? && $?.success? && notify_result(result, options)
+    $? && $?.success? && notify_result(result, options, always_string)
   end
   module_function :notify
 


### PR DESCRIPTION
This small change returns the result of the notification as a ruby-friendly symbol.

The ruby-friendliness is done by downcasing the result and replacing groups of non-word characters with an underscore.  For example, `"@timeout"` is changed to `:_timeout`, `"Close Prompt"` is changed to `:close_promt`, and `"Approve \tThis"` is changed to `:approve_this`. Symbolizing the result allows for easy, memory-efficient and readable code that fits with ruby conventions.

In ruby, all objects except for `nil` and `false` are truthy. If the old version returned `true`, this change will either return a string or `true`. If the old version returned `false` this change will always return `false`. Since the value's truthiness stays the same, this change is backward-compatible and adds a valuable feature. 

Lastly, if the reply option is truthy, then the result is always returned exactly as-is, without the modifications mentioned above, even if the result is empty or it starts with an `@` symbol, like `@timeout`. Symbolizing the result has its benefits, especially when it's predictable, but it doesn't make sense when dealing with user-entered text. While it's tempting to run the symbolisation and ruby-friendliness steps I outlined above on strings like `@timeout`, it could result in some unexcepted consequences. For example, `@penne12 this PR is amazing. I'm going to accept it!` would be changed to `_penne12_this_pr_is_amazing_i_m_going_to_accept_it_`. Without a way to differentiate between user text and actions like `@timeout` in replies, changing any text could result in unexcepted situations. 

This would be super-helpful when trying to get a user's action, and I hope that it can help someone else. Feel free to let me know what you think.
