### PR TITLE
Fix arguments starting with "-" being unrecognized

### DIFF
--- a/Ruby/lib/terminal-notifier.rb
+++ b/Ruby/lib/terminal-notifier.rb
@@ -16,7 +16,7 @@ module TerminalNotifier
 
   def self.execute(verbose, options)
     if available?
-      command = [BIN_PATH, *options.map { |k,v| v = v.to_s; ["-#{k}", "#{Shellwords.escape(v[0,1])}#{v[1..-1]}"] }.flatten]
+      command = [BIN_PATH, *options.map { |k,v| v = v.to_s; ["-#{k}", "#{v[0] == "-" ? " " : ""}#{Shellwords.escape(v[0,1])}#{v[1..-1]}"] }.flatten]
       command = Shellwords.join(command) if RUBY_VERSION < '1.9'
       result = ''
       IO.popen(command) do |stdout|

--- a/Ruby/spec/terminal-notifier_spec.rb
+++ b/Ruby/spec/terminal-notifier_spec.rb
@@ -15,6 +15,13 @@ describe "TerminalNotifier" do
     IO.expects(:popen).with(command).yields(StringIO.new('output'))
     TerminalNotifier.execute(false, :message => '[ZOMG] "OH YEAH"')
   end
+ 
+  it "correctly escapes arguments that start with a dash" do
+    command = [TerminalNotifier::BIN_PATH, '-message', ' -kittens', '-title', ' -rule']
+    command = Shellwords.join(command) if RUBY_VERSION < '1.9'
+    IO.expects(:popen).with(command).yields(StringIO.new('output'))
+    TerminalNotifier.execute(false, :message => '-kittens', :title => '-rule')
+  end
 
   it "returns the result output of the command" do
     TerminalNotifier.execute(false, 'help' => '').should == `'#{TerminalNotifier::BIN_PATH}' -help`


### PR DESCRIPTION
First of all, thank you for this amazing gem!

I recently ran into an issue that when passing arguments (like text, title or subtitle) that start with a "-", no notification would be displayed. I traced this bug down to NSUserDefaults, which doesn't like arguments like `-title "-xyz"` apparently. This PR implements a hack to get around this by inserting a space before such arguments (`-title "-xyz"` becomes `-title " -xyz"`). MacOS removes whitespace, so notifications are shown correctly (without the space) in the notification center.