### PR TITLE
fix: exit correctly when removing message

### DIFF
--- a/Terminal Notifier/AppDelegate.m
+++ b/Terminal Notifier/AppDelegate.m
@@ -200,7 +200,9 @@ isMavericks()
 
     if (remove) {
       [self removeNotificationWithGroupID:remove];
-      if (message == nil) exit(0);
+      if (message == nil || ([message length] == 0)) {
+          exit(0);
+      }
     }
 
     if (message) {


### PR DESCRIPTION
This fixes notification removal when the "sender" field is sent.

It would be great if there was a doc about how to run the tests.  I got this far on my own:

    (cd Ruby && rbenv local 2.0.0-p247)
    (cd Ruby && bundler)
    xcodebuild
    mkdir -p Ruby/vendor/terminal-notifier
    cp -r build/Release/terminal-notifier.app Ruby/vendor/terminal-notifier/
    (cd Ruby && rake)
