### PR TITLE
Repoint gem homepage to julienXX instead of alloy

### DIFF
--- a/Ruby/terminal-notifier.gemspec
+++ b/Ruby/terminal-notifier.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.summary          = 'Send User Notifications on Mac OS X 10.8 or higher.'
   gem.authors          = ["Eloy Duran", "Julien Blanchard"]
   gem.email            = ["eloy.de.enige@gmail.com", "julien@sideburns.eu"]
-  gem.homepage         = 'https://github.com/alloy/terminal-notifier'
+  gem.homepage         = 'https://github.com/julienXX/terminal-notifier'
   gem.license          = 'MIT'
 
   gem.executables      = ['terminal-notifier']


### PR DESCRIPTION
We were parsing this attribute automatically (using [gocardless/bump](https://github.com/gocardless/bump)) - just noticed it wasn't consistent!