### PR TITLE
add flag to ignore "Do not Disturb"

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -150,6 +150,12 @@ Automatically close the alert notification after `NUMBER` seconds.
 
 -------------------------------------------------------------------------------
 
+`-ignoreDnD`
+
+Ignore Do Not Disturb settings and unconditionally show the notification
+
+-------------------------------------------------------------------------------
+
 `-json`
 
 Output the event as JSON.

--- a/Ruby/lib/terminal-notifier.rb
+++ b/Ruby/lib/terminal-notifier.rb
@@ -32,14 +32,14 @@ module TerminalNotifier
   end
 
   # Cleans up the result of a notification, making it easier to work it
-  # 
+  #
   # The result of a notification is downcased, then groups of 1 or more
   # non-word characters are replaced with an underscore, before being
-  # symbolised. 
+  # symbolised.
   #
-  # If the reply option was given, then instead of going through the 
+  # If the reply option was given, then instead of going through the
   # above process, the result is returned with no changes as a string.
-  # 
+  #
   # If the always_string param is set to true, a the result is returned
   # with no changes as a string, like above.
   #
@@ -61,11 +61,11 @@ module TerminalNotifier
     end
   end
   module_function :notify_result
-  
+
   # Sends a User Notification and returns whether or not it was a success.
   #
   # The available options are `:title`, `:group`, `:activate`, `:open`,
-  # `:execute`, `:sender`, and `:sound`. For a description of each option see:
+  # `:execute`, `:sender`, `:sound`, and `:ignoreDnD`. For descriptions, see
   #
   #   https://github.com/alloy/terminal-notifier/blob/master/README.markdown
   #
@@ -79,6 +79,7 @@ module TerminalNotifier
   #   TerminalNotifier.notify('Hello World', :execute => 'say "OMG"')
   #   TerminalNotifier.notify('Hello World', :sender => 'com.apple.Safari')
   #   TerminalNotifier.notify('Hello World', :sound => 'default')
+  #   TerminalNotifier.notify('Hello World', :ignoreDnD => true)
   #
   # Raises if not supported on the current platform.
   def notify(message, options = {}, verbose = false, always_string = false)

--- a/Terminal Notifier/AppDelegate.m
+++ b/Terminal Notifier/AppDelegate.m
@@ -107,6 +107,7 @@ InstallFakeBundleIdentifierHook()
          "       -open URL          The URL of a resource to open when the user clicks the notification.\n" \
          "       -execute COMMAND   A shell command to perform when the user clicks the notification.\n" \
          "       -timeout NUMBER    Close the notification after NUMBER seconds.\n" \
+         "       -ignoreDnD         Send notification even if Do Not Disturb is enabled.\n" \
          "       -json              Output event or value to stdout as JSON.\n" \
          "\n" \
          "When the user activates a notification, the results are logged to the system logs.\n" \
@@ -212,6 +213,10 @@ InstallFakeBundleIdentifierHook()
         options[@"output"] = @"json";
       }
 
+      if([[[NSProcessInfo processInfo] arguments] containsObject:@"-ignoreDnD"] == true) {
+        options[@"ignoreDnD"] = @YES;
+      }
+
       options[@"uuid"] = [NSString stringWithFormat:@"%ld", self.hash];
       options[@"timeout"] = defaults[@"timeout"] ? defaults[@"timeout"] : @"0";
 
@@ -301,6 +306,10 @@ InstallFakeBundleIdentifierHook()
 
   if (sound != nil) {
     userNotification.soundName = [sound isEqualToString: @"default"] ? NSUserNotificationDefaultSoundName : sound;
+  }
+
+  if(options[@"ignoreDnD"]){
+    [userNotification setValue:@YES forKey:@"_ignoresDoNotDisturb"];
   }
 
   NSUserNotificationCenter *center = [NSUserNotificationCenter defaultUserNotificationCenter];


### PR DESCRIPTION
`NSUserNotification` has an undocumented boolean property, `_ignoresDoNotDisturb`, which does exactly what it sounds like. This PR adds a corresponding `-ignoreDnD` flag to the CLI. I was able to successfully build & run this with XCode 9.0.1 on macOS 10.13 (High Sierra), and it appears to work.
