### PR TITLE
Closes Issue #280 errors on macOS Big Sur

### DIFF
--- a/Terminal Notifier/AppDelegate.m
+++ b/Terminal Notifier/AppDelegate.m
@@ -3,7 +3,7 @@
 #import <objc/runtime.h>
 
 NSString * const TerminalNotifierBundleID = @"fr.julienxx.oss.terminal-notifier";
-NSString * const NotificationCenterUIBundleID = @"com.apple.notificationcenterui";
+
 
 NSString *_fakeBundleIdentifier = nil;
 
@@ -129,7 +129,13 @@ InstallFakeBundleIdentifierHook()
     }
 
     NSArray *runningProcesses = [[[NSWorkspace sharedWorkspace] runningApplications] valueForKey:@"bundleIdentifier"];
-    if ([runningProcesses indexOfObject:NotificationCenterUIBundleID] == NSNotFound) {
+    NSString *notificationCenterUIBundleID;
+    if (@available(macOS 10.16, *)) {
+        notificationCenterUIBundleID = @"com.apple.notificationcenterui2";
+    } else {
+        notificationCenterUIBundleID = @"com.apple.notificationcenterui";
+    }
+    if ([runningProcesses indexOfObject:notificationCenterUIBundleID] == NSNotFound) {
       NSLog(@"[!] Unable to post a notification for the current user (%@), as it has no running NotificationCenter instance.", NSUserName());
       exit(1);
     }


### PR DESCRIPTION
It looks like the availability check for Big Sur is "10.16" for now and not "11".  We'll see if that remains or if we need to update.  I have only tested this on my Big Sur machine.  I did not include anything else that updated so as to keep this as vanilla as possible.