### PR TITLE
Update Readme to document where the list of sounds can be found

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -127,7 +127,7 @@ The subtitle of the notification.
 `-sound NAME`
 
 Play the `NAME` sound when the notification appears.
-Sound names are listed in Sound Preferences.
+Sound names are listed in `/System/Library/Sounds`.
 
 Use the special `NAME` “default” for the default notification sound.
 


### PR DESCRIPTION
The names of sounds referenced by `terminal-notifier` match the filenames in the `/System/Library/Sounds` as opposed to the ones listed in **Sound Preferences**.

This addresses the confusion in https://github.com/julienXX/terminal-notifier/issues/283#issuecomment-727597950